### PR TITLE
some validate_length_of options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,10 +36,11 @@ Validation Matchers
       it { should validate_associated(:profile) }
       it { should validate_inclusion_of(:role).to_allow("admin", "member") }
       it { should validate_numericality_of(:age) }
+      it { should validate_length_of(:us_phone).as_exactly(7) }
     end
     
     describe Article do
-      it { should validate_length_of(:title) }
+      it { should validate_length_of(:title).within(4..100) }
     end
 
 Others

--- a/lib/matchers/validations/length_of.rb
+++ b/lib/matchers/validations/length_of.rb
@@ -1,8 +1,99 @@
 module Mongoid
   module Matchers
     module Validations
+      class ValidateLengthOfMatcher < HaveValidationMatcher
+        def initialize(name)
+          super(name, :length)
+        end
+
+        def with_maximum(value)
+          @maximum = value
+          self
+        end
+
+        def with_minimum(value)
+          @minimum = value
+          self
+        end
+
+        def within(value)
+          @within = value
+          self
+        end
+        alias :in :within
+
+        def as_exactly(value)
+          @is = value
+          self
+        end
+        alias :is :as_exactly
+
+        def matches?(actual)
+          return false unless @result = super(actual)
+
+          check_maximum if @maximum
+          check_minimum if @minimum
+          check_range if @within
+          check_exact if @is
+
+          @result
+        end
+
+        def description
+          options_desc = []
+          options_desc << " with maximum #{@maximum}" if @maximum
+          options_desc << " with minimum #{@minimum}" if @minimum
+          options_desc << " within range #{@within}" if @within
+          options_desc << " as exactly #{@is}" if @is
+          super << options_desc.to_sentence
+        end
+
+        private
+
+        def check_maximum
+          actual = @validator.options[:maximum]
+          if actual == @maximum
+            @positive_result_message << " with maximum of #{@maximum}"
+          else
+            @negative_result_message << " with maximum of #{actual}"
+            @result = false
+          end
+        end
+
+        def check_minimum
+          actual = @validator.options[:minimum]
+          if actual == @minimum
+            @positive_result_message << " with minimum of #{@minimum}"
+          else
+            @negative_result_message << " with minimum of #{actual}"
+            @result = false
+          end
+        end
+
+        def check_range
+          min, max = [@within.min, @within.max]
+          actual = @validator.options
+          if actual[:minimum] == min && actual[:maximum] == max
+            @positive_result_message << " with range #{@within.inspect}"
+          else
+            @negative_result_message << " with range #{(actual[:minimum]..actual[:maximum]).inspect}"
+            @result = false
+          end
+        end
+
+        def check_exact
+          actual = @validator.options[:is]
+          if actual == @is
+            @positive_result_message << " is exactly #{@is}"
+          else
+            @negative_result_message << " is exactly #{actual}"
+            @result = false
+          end
+        end
+      end
+
       def validate_length_of(field)
-        HaveValidationMatcher.new(field, :length)
+        ValidateLengthOfMatcher.new(field)
       end
     end
   end

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -20,6 +20,6 @@ describe "Validations" do
   end
   
   describe Article do
-    it { should validate_length_of(:title) }
+    it { should validate_length_of(:title).within(8..16) }
   end
 end


### PR DESCRIPTION
Added a few options:
- within
- with_maximum
- with_minimum
- as_exactly (is)

I thought of adding other options, but things like `message` and `allow_blank` would basically be copied exactly as they are in the existing uniqueness validation matcher -- seems that parameters like these that are shared by many validators could be factored out into modules in mongoid-rspec. I'll give that a whirl if I get the time and motivation :-)
