### PR TITLE
"many" relations support the "inverse_of" option.

### DIFF
--- a/lib/matchers/associations.rb
+++ b/lib/matchers/associations.rb
@@ -33,7 +33,7 @@ module Mongoid
         end
 
         def as_inverse_of(association_inverse_name)
-          raise "#{@association[:type].inspect} does not respond to :inverse_of" unless [BELONGS_TO, EMBEDDED_IN].include?(@association[:type])
+          raise "#{@association[:type].inspect} does not respond to :inverse_of" unless [HAS_MANY, HAS_AND_BELONGS_TO_MANY, BELONGS_TO, EMBEDDED_IN].include?(@association[:type])
           @association[:inverse_of] = association_inverse_name.to_s
           @expectation_message << " which is an inverse of #{@association[:inverse_of].inspect}"
           self

--- a/spec/unit/associations_spec.rb
+++ b/spec/unit/associations_spec.rb
@@ -39,4 +39,8 @@ describe "Associations" do
   describe Permalink do
     it { should be_embedded_in(:linkable).as_inverse_of(:link) }
   end
+
+  describe Site do
+    it { should reference_many(:users).as_inverse_of(:site) }
+  end
 end


### PR DESCRIPTION
mongoid-rspec doesn't allow you to specify that a "many" relation has an "inverse_of" option, despite Mongoid (2.0.1) allowing the option.

This pull request fixes this bug in mongoid-rspec.
