### PR TITLE
Fixed document extension matchers for rspec 2.6

### DIFF
--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -72,24 +72,24 @@ end
 
 RSpec::Matchers.define :be_mongoid_document do
   match do |doc|
-    doc.class.included_modules.should include(Mongoid::Document)
+    doc.class.included_modules.include?(Mongoid::Document).should be_true
   end
 end
 
 RSpec::Matchers.define :be_versioned_document do
   match do |doc|
-    doc.class.included_modules.should include(Mongoid::Versioning)
+    doc.class.included_modules.include?(Mongoid::Versioning).should be_true
   end
 end
 
 RSpec::Matchers.define :be_timestamped_document do
   match do |doc|
-    doc.class.included_modules.should include(Mongoid::Timestamps)
+    doc.class.included_modules.include?(Mongoid::Timestamps).should be_true
   end
 end
 
 RSpec::Matchers.define :be_paranoid_document do
   match do |doc|
-    doc.class.included_modules.should include(Mongoid::Paranoia)
+    doc.class.included_modules.include?(Mongoid::Paranoia).should be_true
   end
 end

--- a/spec/models/site.rb
+++ b/spec/models/site.rb
@@ -1,5 +1,8 @@
 class Site
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
+  include Mongoid::Versioning
   
   field :name
   

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -7,5 +7,12 @@ describe "Document" do
   
   describe Article do
     it { should have_field(:published).of_type(Boolean).with_default_value_of(false) }
-  end  
+  end
+
+  describe Site do
+    it { should be_mongoid_document }
+    it { should be_versioned_document }
+    it { should be_timestamped_document }
+    it { should be_paranoid_document }
+  end
 end


### PR DESCRIPTION
Added tests for: 

```
it { should be_mongoid_document }
it { should be_versioned_document }
it { should be_timestamped_document }
it { should be_paranoid_document }
```

and then fixed them for rspec 2.6 and above (which is needed for rails 3.1)
