### PR TITLE
uniqueness scope validation check

### DIFF
--- a/lib/matchers/validations/uniqueness_of.rb
+++ b/lib/matchers/validations/uniqueness_of.rb
@@ -7,7 +7,7 @@ module Mongoid
         end
         
         def scoped_to(*scope)
-          @scope = [scope].flatten
+          @scope = [scope].flatten.map(&:to_sym)
           self
         end        
         alias_method :scoped_on, :scoped_to
@@ -59,8 +59,8 @@ module Mongoid
         end
 
         def check_scope
-          message = "scope to #{@validator.options[:scope]}"
-          if [@validator.options[:scope]].flatten == @scope
+          message = " scope to #{@validator.options[:scope]}"
+          if [@validator.options[:scope]].flatten.map(&:to_sym) == @scope
             @positive_result_message << message
           else
             @negative_result_message << message


### PR DESCRIPTION
Message before: 

```
Expected User to validate uniqueness of "login" scoped to [:lol]; instead got "uniqueness" validator on "login"scope to site
```

Message after:

```
Expected User to validate uniqueness of "login" scoped to [:lol]; instead got "uniqueness" validator on "login" scope to site
```

Also, the scope check was not working properly with this code:

```
validates :my_field, uniqueness: { scope: 'page' }
```

because the scope was a string. I've added explicit to_sym, so the code always compare the same value types.
