### PR TITLE
Adding in the ability to specify what methods a validation runs on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,20 @@ Validation Matchers
     end
 
     describe User do
-      it { should validate_presence_of(:login) }
-      it { should validate_uniqueness_of(:login).scoped_to(:site) }
-      it { should validate_uniqueness_of(:email).case_insensitive.with_message("is already taken") }
-      it { should validate_format_of(:login).to_allow("valid_login").not_to_allow("invalid login") }
-      it { should validate_associated(:profile) }
-      it { should validate_inclusion_of(:role).to_allow("admin", "member") }
-      it { should validate_confirmation_of(:email) }
-    end
+	    it { should validate_presence_of(:login) }
+	    it { should validate_uniqueness_of(:login).scoped_to(:site) }
+	    it { should validate_uniqueness_of(:email).case_insensitive.with_message("is already taken") }
+	    it { should validate_format_of(:login).to_allow("valid_login").not_to_allow("invalid login") }
+	    it { should validate_associated(:profile) }
+	    it { should validate_exclusion_of(:login).to_not_allow("super", "index", "edit") }
+	    it { should validate_inclusion_of(:role).to_allow("admin", "member") }
+	    it { should validate_confirmation_of(:email) }
+	    it { should validate_presence_of(:age).on(:create, :update) }
+		# The on matcher can take var args or an array. Validations do not fail if on is not specified.
+	    it { should validate_numericality_of(:age).on(:create, :update) }
+	    it { should validate_inclusion_of(:age).to_allow(23..42).on([:create, :update]) }
+	    it { should validate_presence_of(:password).on(:create) }
+	  end
 
     describe Article do
       it { should validate_length_of(:title).within(8..16) }

--- a/lib/matchers/validations.rb
+++ b/lib/matchers/validations.rb
@@ -7,12 +7,13 @@ module Mongoid
         def initialize(field, validation_type)
           @field = field.to_s
           @type = validation_type.to_s
+          @options = {}
         end
                 
         def matches?(actual)
           @klass = actual.is_a?(Class) ? actual : actual.class
           
-          @validator = @klass.validators_on(@field).detect{|v| v.kind.to_s == @type }
+          @validator = @klass.validators_on(@field).detect{|v| v.kind.to_s == @type}
           
           if @validator
             @negative_result_message = "#{@type.inspect} validator on #{@field.inspect}"
@@ -21,8 +22,9 @@ module Mongoid
             @negative_result_message = "no #{@type.inspect} validator on #{@field.inspect}"
             return false
           end
-          
-          true
+          @result = true
+          check_on if @options[:on]          
+          @result
         end
         
         def failure_message_for_should  
@@ -35,6 +37,21 @@ module Mongoid
         
         def description
           "validate #{@type} of #{@field.inspect}"
+        end
+        
+        def on(*on_method)
+          @options[:on] = on_method.flatten
+          self
+        end  
+        
+        def check_on
+          message = " on methods: #{@validator.options[:on]}"
+          if [@validator.options[:on]].flatten == @options[:on]
+            @positive_result_message << message
+          else
+            @negative_result_message << message
+            @result = false
+          end
         end
       end     
     end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -5,6 +5,7 @@ class User
   field :email
   field :role
   field :age, type: Integer
+  field :password, type: String
 
   referenced_in :site, :inverse_of => :users
   references_many :articles, :foreign_key => :author_id
@@ -18,7 +19,8 @@ class User
   validates :email, :uniqueness => { :case_sensitive => false, :scope => :site, :message => "is already taken" }, :confirmation => true
   validates :role, :presence => true, :inclusion => { :in => ["admin", "moderator", "member"]}  
   validates :profile, :presence => true, :associated => true
-  validates :age, :presence => true, :numericality => true, :inclusion => { :in => 23..42 }
+  validates :age, :presence => true, :numericality => true, :inclusion => { :in => 23..42 }, :on => [:create, :update]
+  validates :password, :presence => true, :on => :create
 
   def admin?
     false

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -15,9 +15,10 @@ describe "Validations" do
     it { should validate_exclusion_of(:login).to_not_allow("super", "index", "edit") }
     it { should validate_inclusion_of(:role).to_allow("admin", "member") }
     it { should validate_confirmation_of(:email) }
-    it { should validate_presence_of(:age) }
-    it { should validate_numericality_of(:age) }
-    it { should validate_inclusion_of(:age).to_allow(23..42) }
+    it { should validate_presence_of(:age).on(:create, :update) }
+    it { should validate_numericality_of(:age).on(:create, :update) }
+    it { should validate_inclusion_of(:age).to_allow(23..42).on([:create, :update]) }
+    it { should validate_presence_of(:password).on(:create) }
   end
 
   describe Profile do


### PR DESCRIPTION
Specifying what methods the validation runs on can be important.  

I added this to the base validation because it can be specified on any validation.

I specifically made it so that the validation only fails if you add "on" to your validation.  I don't think it is necessary to make people specify the "on" methods if they don't feel the need to.

If you would rather me implement this a different way let me know.
