### PR TITLE
Fixed copy-paste typo in uniqueness_of

### DIFF
--- a/lib/matchers/validations/uniqueness_of.rb
+++ b/lib/matchers/validations/uniqueness_of.rb
@@ -43,7 +43,7 @@ module Mongoid
           options_desc << " scoped to #{@scope.inspect}" if @scope
           options_desc << " allowing blank values" if @allow_blank
           options_desc << " allowing case insensitive values" if @case_insensitive
-          options_desc << " with message '#{@expected_message}'" if @case_insensitive
+          options_desc << " with message '#{@expected_message}'" if @expected_message
           super << options_desc.to_sentence
         end
         


### PR DESCRIPTION
While looking to expand mongoid-rspec for custom validators, I noticed a typo due to copy paste in uniqueness_of.rb, the if clause for @expected_message was referring to @case_insensitive.
