### PR TITLE
Add mass assignment matcher

### DIFF
--- a/lib/matchers/allow_mass_assignment.rb
+++ b/lib/matchers/allow_mass_assignment.rb
@@ -1,0 +1,101 @@
+# this code is totally extracted from shoulda-matchers gem.
+module Mongoid
+  module Matchers
+    class AllowMassAssignmentOfMatcher # :nodoc:
+      attr_reader :failure_message, :negative_failure_message
+
+      def initialize(attribute)
+        @attribute = attribute.to_s
+        @options = {}
+      end
+
+      def as(role)
+        if active_model_less_than_3_1?
+          raise "You can specify role only in Rails 3.1 or greater"
+        end
+        @options[:role] = role
+        self
+      end
+
+      def matches?(klass)
+        @klass = klass
+        if attr_mass_assignable?
+          if whitelisting?
+            @negative_failure_message = "#{@attribute} was made accessible"
+          else
+            if protected_attributes.empty?
+              @negative_failure_message = "no attributes were protected"
+            else
+              @negative_failure_message = "#{class_name} is protecting " <<
+                "#{protected_attributes.to_a.to_sentence}, " <<
+                "but not #{@attribute}."
+            end
+          end
+          true
+        else
+          if whitelisting?
+            @failure_message = "Expected #{@attribute} to be accessible"
+          else
+            @failure_message = "Did not expect #{@attribute} to be protected"
+          end
+          false
+        end
+      end
+
+      def description
+        "allow mass assignment of #{@attribute}"
+      end
+
+      private
+
+      def role
+        @options[:role] || :default
+      end
+
+      def protected_attributes
+        @protected_attributes ||= (@klass.class.protected_attributes || [])
+      end
+
+      def accessible_attributes
+        @accessible_attributes ||= (@klass.class.accessible_attributes || [])
+      end
+
+      def whitelisting?
+        authorizer.kind_of?(::ActiveModel::MassAssignmentSecurity::WhiteList)
+      end
+
+      def attr_mass_assignable?
+        !authorizer.deny?(@attribute)
+      end
+
+      def authorizer
+        if active_model_less_than_3_1?
+          @klass.class.active_authorizer
+        else
+          @klass.class.active_authorizer[role]
+        end
+      end
+
+      def class_name
+        @klass.class.name
+      end
+
+      def active_model_less_than_3_1?
+        ::ActiveModel::VERSION::STRING.to_f < 3.1
+      end
+    end
+
+    # Ensures that the attribute can be set on mass update.
+    #
+    #   it { should_not allow_mass_assignment_of(:password) }
+    #   it { should allow_mass_assignment_of(:first_name) }
+    #
+    # In Rails 3.1 you can check role as well:
+    #
+    #   it { should allow_mass_assignment_of(:first_name).as(:admin) }
+    #
+    def allow_mass_assignment_of(value)
+      AllowMassAssignmentOfMatcher.new(value)
+    end
+  end
+end

--- a/lib/mongoid-rspec.rb
+++ b/lib/mongoid-rspec.rb
@@ -2,10 +2,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'mongoid'
 require 'rspec'
+require "active_model"
 require 'matchers/document'
 require 'matchers/associations'
 require 'matchers/collections'
 require 'matchers/indexes'
+require 'matchers/allow_mass_assignment'
 require 'matchers/validations'
 require 'matchers/validations/associated'
 require 'matchers/validations/confirmation_of'

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -22,6 +22,9 @@ class User
   validates :age, :presence => true, :numericality => true, :inclusion => { :in => 23..42 }, :on => [:create, :update]
   validates :password, :presence => true, :on => :create
 
+  attr_accessible :login, :email, :age, :password
+  attr_accessible :role, :as => :admin
+
   def admin?
     false
   end

--- a/spec/unit/allow_mass_assignment_spec.rb
+++ b/spec/unit/allow_mass_assignment_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "AllowMassAssignment" do
+  describe User do
+    it { should allow_mass_assignment_of(:login) }
+    it { should allow_mass_assignment_of(:email) }
+    it { should allow_mass_assignment_of(:age) }
+    it { should allow_mass_assignment_of(:password) }
+    it { should allow_mass_assignment_of(:password) }
+    it { should allow_mass_assignment_of(:role).as(:admin) }
+    
+    it { should_not allow_mass_assignment_of(:role) }
+  end
+end


### PR DESCRIPTION
I've added the AllowMassAssignmentMatcher extracted from shoulda-matcher.
https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/active_model/allow_mass_assignment_of_matcher.rb

I did it, because I prefer to explicit my whitelist and test it for future reasons. Actually, I know that mongoid every attribute is on white list until we define any one as protected or accessible.

Doesn't look good?
