### PR TITLE
Support for matching field aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Others
     describe User do
       it { should have_fields(:email, :login) }
       it { should have_field(:active).of_type(Boolean).with_default_value_of(false) }
+      it { should have_field(:s).with_alias(:status) }
       it { should have_fields(:birthdate, :registered_at).of_type(DateTime) }
 
       it { should be_timestamped_document } # if you're declaring `include

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -9,6 +9,11 @@ module Mongoid
         @type = type
         self
       end
+      
+      def with_alias(field_alias)
+        @field_alias = field_alias
+        self
+      end
 
       def with_default_value_of(default)
         @default = default
@@ -27,6 +32,10 @@ module Mongoid
 
             if !@default.nil? and !@klass.fields[attr].default_val.nil? and @klass.fields[attr].default_val != @default
               error << " with default value of #{@klass.fields[attr].default_val}"
+            end
+            
+            if @field_alias and @klass.fields[attr].options[:as] != @field_alias
+              error << " with alias #{@klass.fields[attr].options[:as]}"
             end
 
             @errors.push("field #{attr.inspect}" << error) unless error.blank?
@@ -48,6 +57,7 @@ module Mongoid
       def description
         desc = "have #{@attributes.size > 1 ? 'fields' : 'field'} named #{@attributes.collect(&:inspect).to_sentence}"
         desc << " of type #{@type.inspect}" if @type
+        desc << " with alias #{@field_alias}" if @field_alias
         desc << " with default value of #{@default.inspect}" if !@default.nil?
         desc
       end


### PR DESCRIPTION
This threw me for a loop at first. I have a Mongoid document with a field defined like so:

``` ruby
field :s, as: :status
```

The following spec fails:

``` ruby
it { should have_field(:status) }
```

It turns out there wasn't a way to directly test for the alias. So I added support for it.

``` ruby
it { should have_field(:s).with_alias(:status) }
```
