### PR TITLE
Add autobuild for has_one and embeds_one associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Association Matchers
       it { should have_many(:articles).with_foreign_key(:author_id) }
 
       it { should have_one(:record) }
+      #can verify autobuild is set to true
+      it { should have_one(:record).with_autobuild }
 
       it { should have_many :comments }
 

--- a/lib/matchers/associations.rb
+++ b/lib/matchers/associations.rb
@@ -57,6 +57,12 @@ module Mongoid
           self
         end
 
+        def with_autobuild
+          @association[:autobuild] = true
+          @expectation_message << " which specifies autobuild as #{@association[:autobuild].to_s}"
+          self
+        end
+
         def stored_as(store_as)
           raise NotImplementedError, "`references_many #{@association[:name]} :stored_as => :array` has been removed in Mongoid 2.0.0.rc, use `references_and_referenced_in_many #{@association[:name]}` instead"
         end
@@ -117,6 +123,15 @@ module Mongoid
               return false
             else
               @positive_result_message = "#{@positive_result_message} which set autosave"
+            end
+          end
+
+          if @association[:autobuild]
+            if metadata.autobuilding? != true
+              @negative_result_message = "#{@positive_result_message} which did not set autobuild"
+              return false
+            else
+              @positive_result_message = "#{@positive_result_message} which set autobuild"
             end
           end
 

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -14,7 +14,7 @@ class User
   has_many :articles, :foreign_key => :author_id
   has_many :comments, :dependent => :destroy, :autosave => true
   has_and_belongs_to_many :children, :class_name => "User"
-  has_one :record
+  has_one :record, :autobuild => true
 
   embeds_one :profile
 

--- a/spec/unit/associations_spec.rb
+++ b/spec/unit/associations_spec.rb
@@ -4,7 +4,7 @@ describe "Associations" do
   describe User do
     it { should have_many(:articles).with_foreign_key(:author_id) }
 
-    it { should have_one(:record) }
+    it { should have_one(:record).with_autobuild }
 
     it { should have_many(:comments).with_dependent(:destroy).with_autosave }
 


### PR DESCRIPTION
In order to have autobuild being tested, I've added with_autobuild method that goes into the chain after have_one or embed_one methods.
