### PR TITLE
Support for callbacks matcher

### DIFF
--- a/lib/matchers/callbacks.rb
+++ b/lib/matchers/callbacks.rb
@@ -1,0 +1,68 @@
+module Mongoid
+  module Matchers
+    class HaveCallbackMatcher
+      KINDS = %w[ before around after ]
+
+      def initialize( *args )
+        @methods = args || []
+      end
+
+      def matches?( klass )
+        return false unless @kind
+
+        @methods.each do |method|
+          filters = klass.class.send( "_#{@operation}_callbacks".to_sym ).select do |c|
+            c.filter == method && c.kind == @kind && c.options[:on] == @on
+          end
+          return false if filters.empty?
+        end
+      end
+
+      KINDS.each do |kind|
+        define_method( kind.to_sym ) do |op|
+          @operation = op
+          @kind = kind.to_sym
+          self
+        end
+      end
+
+      def on( action )
+        @on = action
+        self
+      end
+
+      def failure_message_for_should
+        failure_message( true )
+      end
+
+      def failure_message_for_should_not
+        failure_message( false )
+      end
+
+      def description
+        msg = "call #{@methods.join(", ")}"
+        msg << " #{@kind} #{@operation}" if @operation
+        msg << " on #{@on}" if @on
+        msg
+      end
+
+      protected
+      def failure_message( should )
+        if @kind
+          msg = "Expected method#{@methods.size > 1 ? 's' : ''} #{@methods.join(", ")} #{should ? '' : 'not ' }to be called"
+          msg << " #{@kind} #{@operation}" if @operation
+          msg << " on #{@on}" if @on
+          msg
+        else
+          "Callback#{@methods.size > 1 ? 's' : '' } #{@methods.join(", ")} can"\
+          "not be tested against undefined lifecycle. Use .before, .after or .around"
+        end
+      end
+
+    end
+
+    def callback( *args )
+      HaveCallbackMatcher.new( *args )
+    end
+  end
+end

--- a/lib/mongoid-rspec.rb
+++ b/lib/mongoid-rspec.rb
@@ -5,6 +5,7 @@ require 'rspec'
 require "active_model"
 require 'matchers/document'
 require 'matchers/associations'
+require 'matchers/callbacks'
 require 'matchers/collections'
 require 'matchers/indexes'
 require 'matchers/allow_mass_assignment'

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -32,7 +32,17 @@ class User
 
   accepts_nested_attributes_for :articles, :comments
 
+  before_save :callback1
+  after_save :callback2
+
+  before_validation :callback1, :callback2
+  after_validation :callback3, on: :create
+
   def admin?
     false
   end
+
+  def callback1; true; end
+  def callback2; true; end
+  def callback3; true; end
 end

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe "Callbacks" do
+  describe User do
+    it { should callback(:callback1).before(:save) }
+    it { should callback(:callback2).after(:save) }
+    it { should callback(:callback1, :callback2).before(:validation) }
+    it { should callback(:callback3).after(:validation).on(:create) }
+  end
+end
+


### PR DESCRIPTION
Support for callbacks as suggested in #97.

Only `:on` option supported. 
