### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Add to your Gemfile
 Drop in existing or dedicated support file in spec/support (spec/support/mongoid.rb)
 
 ```ruby
-RSpec.configure do |configuration|
-  configuration.include Mongoid::Matchers
+RSpec.configure do |config|
+  config.include Mongoid::Matchers, type: :model
 end
 ```
 


### PR DESCRIPTION
Restrict the usage of Mongoid::Matchers on rspec configuration to avoid
this issue https://github.com/jnicklas/capybara/issues/506 when using
capybara
