### PR TITLE
rspec stopped explicitly requiring expectations

### DIFF
--- a/lib/mongoid-rspec.rb
+++ b/lib/mongoid-rspec.rb
@@ -1,7 +1,9 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'mongoid'
-require 'rspec'
+require 'rspec/core'
+require 'rspec/expectations'
+require 'rspec/mocks'
 require "active_model"
 require 'matchers/document'
 require 'matchers/associations'


### PR DESCRIPTION
It seems that rspec stopped requiring expectations and mocks explicitly https://github.com/rspec/rspec/commit/15ef280ac74b03f612d6038f484d80226fb38e03 Because of that I always getting following error. This should fix error.

`undefined method 'define' for RSpec::Matchers:Module`  `/mongoid-rspec-1.9.0/lib/matchers/document.rb:89`
