### PR TITLE
Require mongoid-compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ services: mongodb
 language: ruby
 matrix:
   include:
+    - rvm: 2.5.0
+      env:
+        - MONGOID_VERSION=6
     - rvm: 2.4.0
       env:
         - MONGOID_VERSION=6
@@ -19,6 +22,7 @@ matrix:
         - MONGOID_VERSION=3
     - rvm: 2.3.0
   allow_failures:
+    - rvm: 2.5.0
     - rvm: 2.4.0
     - rvm: ruby-head
     - rvm: jruby-head

--- a/lib/mongoid/rspec.rb
+++ b/lib/mongoid/rspec.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'mongoid'
+require 'mongoid-compatibility'
 require 'rspec/core'
 require 'rspec/expectations'
 require 'rspec/mocks'


### PR DESCRIPTION
This error show when using from source
```
gem 'mongoid-rspec', github: 'mongoid-rspec/mongoid-rspec'
```
```
NameError: uninitialized constant Mongoid::Compatibility
/Users/matheus/.rvm/gems/ruby-2.5.0/bundler/gems/mongoid-rspec-472f1460c23d/lib/mongoid/rspec.rb:8:in `<top (required)>'
/Users/matheus/.rvm/gems/ruby-2.5.0/bundler/gems/mongoid-rspec-472f1460c23d/lib/mongoid-rspec.rb:1:in `<top (required)>'
```

Require ```mongoid-compatibility``` on ```lib/mongoid/rspec.rb``` fix this problem.