### PR TITLE
Do not depend on `rspec` meta gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 4.0.2 (Next)
 
 * [#221](https://github.com/mongoid/mongoid-rspec/pull/221): Support `ordered_by` for Mongoid 5 and earlier - [@stim371](https://github.com/stim371).
+* [#222](https://github.com/mongoid/mongoid-rspec/pull/222): Do not depend on `rspec` meta gem - [@lucasmazza](https://github.com/lucasmazza).
 * Your contribution here.
 
 ### 4.0.1 (6/15/2018)

--- a/mongoid-rspec.gemspec
+++ b/mongoid-rspec.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_dependency 'mongoid', '>= 3.1'
-  s.add_dependency 'rspec', '~> 3.3'
+  s.add_dependency 'rspec-core', '~> 3.3'
+  s.add_dependency 'rspec-expectations', '~> 3.3'
+  s.add_dependency 'rspec-mocks', '~> 3.3'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_dependency 'mongoid-compatibility', '>= 0.5.1'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'bundler'
 Bundler.setup
 
 require 'mongoid'
-require 'rspec'
 require 'rspec/core'
 require 'rspec/expectations'
 require 'mongoid/compatibility'


### PR DESCRIPTION
The `rspec` gem is a shortcut to depend on `rspec-core`, `rspec-expectations` and `rspec-mocks`, but depending on it directly clashes with the `rspec-rails` gem that is also a bag of sub RSpec dependencies.

This helps with scenarios where one meta gem locks the update of another one, like in the following:

```
bundle update rspec-rails
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies.......
Bundler could not find compatible versions for gem "rspec-mocks":
  In Gemfile:
    mongoid-rspec was resolved to 4.0.1, which depends on
      rspec (~> 3.3) was resolved to 3.7.0, which depends on
        rspec-mocks (~> 3.7.0)

    rspec-rails (= 3.8.0) was resolved to 3.8.0, which depends on
      rspec-mocks (~> 3.8.0)
```