### PR TITLE
Fix transform_values deprecation in Rails 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#221](https://github.com/mongoid/mongoid-rspec/pull/221): Support `ordered_by` for Mongoid 5 and earlier - [@stim371](https://github.com/stim371).
 * [#222](https://github.com/mongoid/mongoid-rspec/pull/222): Do not depend on `rspec` meta gem - [@lucasmazza](https://github.com/lucasmazza).
+* [#231](https://github.com/mongoid/mongoid-rspec/pull/231): Fix transform_values deprecation in rails 6 - [@yads](https://github.com/yads).
 * Your contribution here.
 
 ### 4.0.1 (6/15/2018)

--- a/lib/mongoid/rspec.rb
+++ b/lib/mongoid/rspec.rb
@@ -6,7 +6,7 @@ require 'rspec/core'
 require 'rspec/expectations'
 require 'rspec/mocks'
 require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/hash/transform_values' if Mongoid::Compatibility::Version.mongoid4_or_newer?
+require 'active_support/core_ext/hash/transform_values' if Mongoid::Compatibility::Version.mongoid4_or_newer? && ActiveSupport.version < Gem::Version.new('6')
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string/inflections'
 


### PR DESCRIPTION
Do not require transform_values if ActiveSupport is version 6 or higher