### PR TITLE
Add support for if/unless validator options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 4.1.1 (Next)
 
+* [#239](https://github.com/mongoid/mongoid-rspec/pull/239): Add support for if/unless validator options - [@knovoselic](https://github.com/knovoselic).
 * Your contribution here.
 
 ### 4.1.0 (6/12/2020)

--- a/README.md
+++ b/README.md
@@ -315,6 +315,22 @@ RSpec.describe Person do
    # should redefine the kind method to return :custom, i.e. "def self.kind() :custom end"
   it { is_expected.to custom_validate(:ssn).with_validator(SsnValidator) }
 end
+
+# If you're using validators with if/unless conditionals, spec subject must be object instance
+# This is supported on Mongoid 4 and newer
+Rspec.describe User do
+  context 'when user has `admin` role' do
+    subject { User.new(role: 'admin') }
+
+    it { is_expected.to validate_length_of(:password).greater_than(20) }
+  end
+
+  context 'when user does not have `admin` role' do
+    subject { User.new(role: 'member') }
+
+    it { is_expected.not_to validate_length_of(:password) }
+  end
+end
 ```
 
 ### Mass Assignment Matcher

--- a/spec/models/article.rb
+++ b/spec/models/article.rb
@@ -9,6 +9,7 @@ class Article
   field :number_of_comments, type: Integer
   field :status, type: Symbol
   field :deletion_date, type: DateTime, default: nil
+  field :reviewer, type: String, default: nil
 
   embeds_many :comments, cascade_callbacks: true, inverse_of: :article
   embeds_one :permalink, inverse_of: :linkable
@@ -23,6 +24,10 @@ class Article
   validates_length_of :content, minimum: 200
 
   validates_absence_of :deletion_date if Mongoid::Compatibility::Version.mongoid4_or_newer?
+
+  validates_presence_of :reviewer, unless: -> { status == :pending }
+
+  validates_absence_of :comments, unless: :allow_comments if Mongoid::Compatibility::Version.mongoid4_or_newer?
 
   index({ title: 1 }, unique: true, background: true, drop_dups: true)
   index(published: 1)

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -30,9 +30,17 @@ class User
   validates :provider_uid, presence: true
   validates :locale, inclusion: { in: ->(_user) { %i[en ru] } }
 
+  with_options if: :admin? do
+    validates :password, length: { minimum: 20 }
+  end
+
+  with_options if: -> { role == 'moderator' } do
+    validates :password, length: { minimum: 10 }
+  end
+
   accepts_nested_attributes_for :articles, :comments
 
   def admin?
-    false
+    role == 'admin'
   end
 end

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -59,3 +59,63 @@ RSpec.describe 'Validations' do
     it { is_expected.to validate_format_of(:to).with_message('format') }
   end
 end
+
+if Mongoid::Compatibility::Version.mongoid4_or_newer?
+  RSpec.describe 'Conditional validations' do
+    describe 'validations with if condition using symbol' do
+      context 'when the condition is met' do
+        subject { User.new(role: 'admin') }
+
+        it { is_expected.to validate_length_of(:password).greater_than(20) }
+      end
+
+      context 'when the condition is not met' do
+        subject { User.new(role: 'member') }
+
+        it { is_expected.not_to validate_length_of(:password) }
+      end
+    end
+
+    describe 'validations with if condition using lambda' do
+      context 'when the condition is met' do
+        subject { User.new(role: 'moderator') }
+
+        it { is_expected.to validate_length_of(:password).greater_than(10) }
+      end
+
+      context 'when the condition is not met' do
+        subject { User.new(role: 'member') }
+
+        it { is_expected.not_to validate_length_of(:password) }
+      end
+    end
+
+    describe 'validations with unless condition using symbol' do
+      context 'when the condition is met' do
+        subject { Article.new(allow_comments: false) }
+
+        it { is_expected.to validate_absence_of(:comments) }
+      end
+
+      context 'when the condition is not met' do
+        subject { Article.new(allow_comments: true) }
+
+        it { is_expected.not_to validate_absence_of(:comments) }
+      end
+    end
+
+    describe 'validations with unless condition using lambda' do
+      context 'when the condition is met' do
+        subject { Article.new(status: :rejected) }
+
+        it { is_expected.to validate_presence_of(:reviewer) }
+      end
+
+      context 'when the condition is not met' do
+        subject { Article.new(status: :pending) }
+
+        it { is_expected.not_to validate_presence_of(:reviewer) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for testing validators which are triggered only under a certain condition. The change supports if/unless options with symbol or lambda parameters as the conditions.
